### PR TITLE
Add dataset preparation guide and download script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,14 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+# Generated datasets and experiment artifacts
+data/gsm8k/
+data/mbpp/
 data/math/
+data/processed/
+outputs/
+experiments/results/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -4,82 +4,112 @@ This repository contains the implementation for the AAAI-26 paper **"BAMAS: Stru
 
 ## Overview
 
-BAMAS is a framework for constructing budget-aware multi-agent systems that optimally balance performance and cost. The system automatically selects appropriate LLMs and collaboration topologies to solve tasks within specified budget constraints.
+BAMAS is a framework for constructing budget-aware multi-agent systems that balance performance and cost. The system selects both LLM configurations and collaboration topologies under a user-specified budget constraint.
 
 ## Project Structure
 
-```
+```text
 BAMAS/
-├── eapae_agent_sys/          # Core system implementation
-│   ├── agents/               # Agent implementations and configurations
-│   ├── planning/             # Resource planning and topology selection
-│   ├── execution/            # Task execution engine
-│   ├── utils/                # Utility functions and API wrappers
-│   └── data_processing/      # Dataset loaders and preprocessing
-├── configs/                  # Configuration files
-│   ├── 0_agent_library*.yml  # Agent specifications
-│   ├── 1_role_compatibility.yml # Role definitions
-│   ├── 2_collaboration_patterns.json # Topology configurations
-│   ├── 3_training_params*.yml # Training parameters
-│   └── 4_*_dataset_config.yml # Dataset configurations
-├── scripts/                  # Training data generation scripts
-├── experiments/              # Experiment execution scripts
-├── main_train_offline.py     # Main training script
-└── data/                     # Dataset storage (not included)
+|-- eapae_agent_sys/          # Core system implementation
+|   |-- agents/               # Agent implementations and configurations
+|   |-- planning/             # Resource planning and topology selection
+|   |-- execution/            # Task execution engine
+|   |-- utils/                # Utility functions and API wrappers
+|   `-- data_processing/      # Dataset loaders and preprocessing
+|-- configs/                  # Configuration files
+|-- scripts/                  # Dataset download and cache generation scripts
+|-- experiments/              # Experiment entry points
+|-- main_train_offline.py     # Offline RL training entry point
+`-- data/                     # Generated benchmark data and caches (not tracked)
 ```
 
-## Key Components
+## Dataset Preparation
 
-### Core System (`eapae_agent_sys/`)
+The repository does **not** include benchmark data or generated offline RL caches. Those files are expected to be created locally.
 
-- **Agents**: Modular agent implementations for different roles (planner, executor, critic)
-- **Planning**: Budget-constrained resource allocation and collaboration pattern selection
-- **Execution**: Multi-agent task execution engine with various topology support
-- **Utils**: Configuration management, LLM API wrappers, and evaluation utilities
-- **Data Processing**: Dataset loaders for MATH, MBPP, and GSM8K benchmarks
+Raw benchmark datasets can be downloaded into the repository layout with:
 
-### Configuration System
+```bash
+pip install -r requirements.txt
+python scripts/download_real_datasets.py --datasets gsm8k mbpp math
+```
 
-- **Agent Libraries**: Define available LLMs and their capabilities
-- **Collaboration Patterns**: Specify different multi-agent topologies (linear, star, feedback, planner-driven)
-- **Training Parameters**: Control reinforcement learning and optimization settings
-- **Dataset Configs**: Manage benchmark-specific configurations
+The script downloads from the following public sources:
 
-### Experiment Framework
+| Dataset | Public source | Local files created |
+| --- | --- | --- |
+| GSM8K | Hugging Face `openai/gsm8k` | `data/gsm8k/train.jsonl`, `data/gsm8k/test.jsonl` |
+| MBPP | Hugging Face `google-research-datasets/mbpp` | `data/mbpp/mbpp.jsonl` and processed split files under `data/processed/mbpp/` |
+| MATH | Hugging Face `EleutherAI/hendrycks_math` | `data/math/train/`, `data/math/test/`, and sampled subsets under `data/processed/math/` |
 
-- **Training**: Offline reinforcement learning for topology selection
-- **Evaluation**: Performance assessment across different budgets and datasets
+Detailed paths, cache-generation commands, and batch-generation notes are documented in [docs/datasets.md](docs/datasets.md).
 
 ## Quick Start
 
-### 1. Environment Setup
+### 1. Install dependencies
 
 ```bash
-# Install dependencies
 pip install -r requirements.txt
-
-# Configure API keys in configs/secrets.yml
 ```
 
-### 2. Training
+### 2. Configure API keys
 
-```bash
-# Train the topology selection policy
-python main_train_offline.py --dataset math --config configs/3_training_params_math.yml
+Create `configs/secrets.yml` before generating offline RL data. Raw benchmark download does not require API keys, but cache generation does.
+
+```yaml
+api_keys:
+  deepseek: "YOUR_DEEPSEEK_API_KEY"
+  openai: "YOUR_OPENAI_COMPATIBLE_API_KEY"
+api_bases:
+  openai: "https://your-openai-compatible-base/v1"
 ```
 
-### 3. Evaluation
+### 3. Download the benchmark datasets
 
 ```bash
-# Run experiments with trained model
-python experiments/main_experiment_math.py --model_path models/trained_model.pth
+python scripts/download_real_datasets.py --datasets gsm8k mbpp math
+```
+
+### 4. Generate the offline RL dataset
+
+```bash
+# GSM8K
+python scripts/generate_training_cache.py --num_samples -1 --num_budget_steps 5 --num_workers 16
+
+# MATH
+python scripts/generate_math_training_cache.py --num_samples -1 --num_budget_steps 3 --num_workers 24
+
+# MBPP
+python scripts/generate_mbpp_training_cache.py --num_samples -1 --num_budget_steps 5 --num_workers 16
+```
+
+This creates the dataset files expected by offline training:
+
+- `data/processed/offline_rl_dataset.jsonl`
+- `data/processed/math/offline_rl_dataset.jsonl`
+- `data/processed/mbpp/offline_rl_dataset.jsonl`
+
+### 5. Train the topology selection policy
+
+```bash
+python main_train_offline.py --dataset_name gsm8k
+python main_train_offline.py --dataset_name math
+python main_train_offline.py --dataset_name mbpp
+```
+
+### 6. Run evaluation
+
+```bash
+python experiments/main_experiment.py
+python experiments/main_experiment_math.py
+python experiments/main_experiment_mbpp.py
 ```
 
 ## Supported Datasets
 
-- **MATH**: Mathematical reasoning problems
-- **MBPP**: Python code generation tasks  
 - **GSM8K**: Grade school math word problems
+- **MATH**: Competition-style mathematical reasoning problems
+- **MBPP**: Python code generation tasks
 
 ## Key Features
 
@@ -97,8 +127,3 @@ To be released
 ## License
 
 This project is licensed under the terms specified in the LICENSE file.
-
-## Notes
-
-- The `data/` directory should contain the benchmark datasets
-- API keys for LLM providers should be configured in `configs/secrets.yml`

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,0 +1,93 @@
+# Dataset And Offline Cache Preparation
+
+This document explains where the BAMAS training data comes from and how to generate the `offline_rl_dataset.jsonl` files used by offline training.
+
+## What Is Tracked In Git
+
+The repository does not store:
+
+- Raw benchmark datasets under `data/`
+- Generated offline RL datasets under `data/processed/`
+- Training outputs under `outputs/` or experiment summaries under `experiments/results/`
+
+These files are generated locally because they are large and, for offline RL caches, depend on the configured model providers and budget settings.
+
+## Public Dataset Sources
+
+| Dataset | Public source | Download command | Main local outputs |
+| --- | --- | --- | --- |
+| GSM8K | Hugging Face `openai/gsm8k` | `python scripts/download_real_datasets.py --datasets gsm8k` | `data/gsm8k/train.jsonl`, `data/gsm8k/test.jsonl` |
+| MBPP | Hugging Face `google-research-datasets/mbpp` | `python scripts/download_real_datasets.py --datasets mbpp` | `data/mbpp/mbpp.jsonl`, processed splits under `data/processed/mbpp/` |
+| MATH | Hugging Face `EleutherAI/hendrycks_math` | `python scripts/download_real_datasets.py --datasets math` | `data/math/train/`, `data/math/test/`, sampled subsets under `data/processed/math/` |
+
+To download all supported datasets in one step:
+
+```bash
+python scripts/download_real_datasets.py --datasets gsm8k mbpp math
+```
+
+## Secrets File
+
+Raw dataset download does not require API keys.
+
+Offline RL cache generation does require a `configs/secrets.yml` file because each sample is executed through the configured LLM providers. A minimal example is:
+
+```yaml
+api_keys:
+  deepseek: "YOUR_DEEPSEEK_API_KEY"
+  openai: "YOUR_OPENAI_COMPATIBLE_API_KEY"
+api_bases:
+  openai: "https://your-openai-compatible-base/v1"
+```
+
+## Offline RL Dataset Generation
+
+After downloading the raw benchmarks and configuring `configs/secrets.yml`, generate the offline RL datasets with the dataset-specific cache scripts:
+
+```bash
+# GSM8K
+python scripts/generate_training_cache.py --num_samples -1 --num_budget_steps 5 --num_workers 16
+
+# MATH
+python scripts/generate_math_training_cache.py --num_samples -1 --num_budget_steps 3 --num_workers 24
+
+# MBPP
+python scripts/generate_mbpp_training_cache.py --num_samples -1 --num_budget_steps 5 --num_workers 16
+```
+
+The canonical output files used by `main_train_offline.py` are:
+
+- `data/processed/offline_rl_dataset.jsonl`
+- `data/processed/math/offline_rl_dataset.jsonl`
+- `data/processed/mbpp/offline_rl_dataset.jsonl`
+
+## Batch Generation
+
+If full cache generation is too expensive to run in one shot, the cache scripts can generate batches with `--begin_with` and `--num_samples`. In that case the output filenames include a batch suffix such as:
+
+- `data/processed/offline_rl_dataset_batch_0_499.jsonl`
+- `data/processed/math/offline_rl_dataset_batch_0_999.jsonl`
+- `data/processed/mbpp/offline_rl_dataset_batch_0_499.jsonl`
+
+Batch files can be merged with:
+
+```bash
+python scripts/merge_batch_datasets.py --input_pattern "data/processed/offline_rl_dataset_batch_*.jsonl" --output "data/processed/offline_rl_dataset.jsonl" --verify
+python scripts/merge_batch_datasets.py --input_pattern "data/processed/math/offline_rl_dataset_batch_*.jsonl" --output "data/processed/math/offline_rl_dataset.jsonl" --verify
+python scripts/merge_batch_datasets.py --input_pattern "data/processed/mbpp/offline_rl_dataset_batch_*.jsonl" --output "data/processed/mbpp/offline_rl_dataset.jsonl" --verify
+```
+
+## Training Commands
+
+Once the canonical offline datasets exist, offline training can be launched with:
+
+```bash
+python main_train_offline.py --dataset_name gsm8k
+python main_train_offline.py --dataset_name math
+python main_train_offline.py --dataset_name mbpp
+```
+
+## Notes
+
+- `scripts/download_real_datasets.py` also creates processed helper files used by the current loaders, such as the GSM8K curriculum file and the sampled MATH subsets.
+- The provided MATH preparation step writes the full raw dataset to `data/math/` and also builds deterministic `1000`-sample train and test subsets under `data/processed/math/`, which are used by the default MATH cache-generation script.

--- a/main_train_offline.py
+++ b/main_train_offline.py
@@ -12,6 +12,22 @@ from torch.utils.data import Dataset, DataLoader
 from torch.distributions import Categorical
 from eapae_agent_sys.utils.config_loader import ConfigLoader
 from eapae_agent_sys.planning.high_level_policy import HighLevelPolicy
+
+
+def resolve_offline_dataset_path(dataset_name, configured_path):
+    """Return the canonical offline dataset path, with a fallback for legacy MBPP caches."""
+    candidate_paths = [configured_path]
+    if dataset_name.lower() == "mbpp":
+        legacy_path = configured_path.replace("offline_rl_dataset.jsonl", "offline_rl_dataset_mbpp.jsonl")
+        candidate_paths.append(legacy_path)
+    for path in candidate_paths:
+        if os.path.exists(path):
+            if path != configured_path:
+                print(f"Using legacy offline dataset path: {path}")
+            return path
+    return configured_path
+
+
 class OfflineRLDataset(Dataset):
     """PyTorch Dataset for loading the pre-generated offline RL experiences."""
     def __init__(self, file_path, use_ranking=True, use_weighted_ranking=False, config_loader=None):
@@ -406,10 +422,16 @@ def main(args):
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    dataset_path = params['data']['offline_dataset_path']
+    dataset_path = resolve_offline_dataset_path(args.dataset_name, params['data']['offline_dataset_path'])
     if not os.path.exists(dataset_path):
         print(f"Error: Offline dataset not found at {dataset_path}")
-        print("Please run 'scripts/3_generate_training_cache.py' first.")
+        print("Download the raw benchmark data first:")
+        print("  python scripts/download_real_datasets.py --datasets gsm8k mbpp math")
+        print("Then generate the offline RL cache for your dataset:")
+        print("  gsm8k -> python scripts/generate_training_cache.py --num_samples -1")
+        print("  math  -> python scripts/generate_math_training_cache.py --num_samples -1")
+        print("  mbpp  -> python scripts/generate_mbpp_training_cache.py --num_samples -1")
+        print("More details are available in docs/datasets.md.")
         return
     dataset = OfflineRLDataset(dataset_path, use_ranking=False, use_weighted_ranking=False, config_loader=config_loader)
     dataloader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True, num_workers=4)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ tqdm
 requests
 duckduckgo-search
 numpy
+datasets

--- a/scripts/download_real_datasets.py
+++ b/scripts/download_real_datasets.py
@@ -1,0 +1,137 @@
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from datasets import get_dataset_config_names, load_dataset
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from eapae_agent_sys.data_processing.prepare_gsm8k_dataset import main as prepare_gsm8k_curriculum
+from eapae_agent_sys.data_processing.sample_math_subset import create_math_subset
+
+
+DATASET_SOURCES = {
+    "gsm8k": "Hugging Face dataset openai/gsm8k",
+    "mbpp": "Hugging Face dataset google-research-datasets/mbpp",
+    "math": "Hugging Face dataset EleutherAI/hendrycks_math",
+}
+
+
+def ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_jsonl(path: Path, rows) -> None:
+    ensure_parent(path)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def reset_dir(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def download_gsm8k() -> None:
+    print(f"Downloading GSM8K from {DATASET_SOURCES['gsm8k']}")
+    dataset = load_dataset("openai/gsm8k", "main")
+    train_rows = [{"question": row["question"], "answer": row["answer"]} for row in dataset["train"]]
+    test_rows = [{"question": row["question"], "answer": row["answer"]} for row in dataset["test"]]
+
+    train_path = ROOT / "data" / "gsm8k" / "train.jsonl"
+    test_path = ROOT / "data" / "gsm8k" / "test.jsonl"
+    write_jsonl(train_path, train_rows)
+    write_jsonl(test_path, test_rows)
+
+    # Optional processed curriculum file used by some utilities.
+    prepare_gsm8k_curriculum()
+
+
+def download_mbpp() -> None:
+    print(f"Downloading MBPP from {DATASET_SOURCES['mbpp']}")
+    dataset = load_dataset("google-research-datasets/mbpp")
+    split_to_filename = {
+        "train": "train.jsonl",
+        "test": "test.jsonl",
+        "validation": "val.jsonl",
+        "prompt": "few_shot.jsonl",
+    }
+
+    raw_rows = []
+    for split_name in ("prompt", "test", "validation", "train"):
+        split_rows = []
+        for row in dataset[split_name]:
+            clean_row = {
+                "task_id": row["task_id"],
+                "text": row["text"],
+                "code": row["code"],
+                "test_list": row["test_list"],
+                "test_setup_code": row["test_setup_code"],
+                "challenge_test_list": row["challenge_test_list"],
+            }
+            raw_rows.append(clean_row)
+            split_rows.append(clean_row)
+        write_jsonl(ROOT / "data" / "processed" / "mbpp" / split_to_filename[split_name], split_rows)
+
+    raw_rows.sort(key=lambda item: item["task_id"])
+    write_jsonl(ROOT / "data" / "mbpp" / "mbpp.jsonl", raw_rows)
+
+
+def download_math() -> None:
+    print(f"Downloading MATH from {DATASET_SOURCES['math']}")
+    train_root = ROOT / "data" / "math" / "train"
+    test_root = ROOT / "data" / "math" / "test"
+    reset_dir(train_root)
+    reset_dir(test_root)
+
+    for config_name in get_dataset_config_names("EleutherAI/hendrycks_math"):
+        for split_name in ("train", "test"):
+            split_dir = (train_root if split_name == "train" else test_root) / config_name
+            split_dir.mkdir(parents=True, exist_ok=True)
+            split_dataset = load_dataset("EleutherAI/hendrycks_math", config_name, split=split_name)
+            for idx, row in enumerate(split_dataset):
+                row_to_save = dict(row)
+                if not row_to_save.get("type"):
+                    row_to_save["type"] = config_name
+                output_path = split_dir / f"{idx:05d}.json"
+                with output_path.open("w", encoding="utf-8") as handle:
+                    json.dump(row_to_save, handle, ensure_ascii=False)
+
+    create_math_subset()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download BAMAS benchmark datasets into the repository layout.")
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        default=["all"],
+        choices=["all", "gsm8k", "mbpp", "math"],
+        help="Which datasets to download.",
+    )
+    args = parser.parse_args()
+
+    selected = set(args.datasets)
+    if "all" in selected:
+        selected = {"gsm8k", "mbpp", "math"}
+
+    os.chdir(ROOT)
+    if "gsm8k" in selected:
+        download_gsm8k()
+    if "mbpp" in selected:
+        download_mbpp()
+    if "math" in selected:
+        download_math()
+
+    print("Dataset download and local preprocessing complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_mbpp_training_cache.py
+++ b/scripts/generate_mbpp_training_cache.py
@@ -229,8 +229,6 @@ def generate_cache_single_pattern_budget(args, pattern_idx: int, budget_idx: int
             p.join()
     output_path = params['data']['offline_dataset_path']
     base_path, ext = os.path.splitext(output_path)
-    if "_mbpp" not in base_path:
-        base_path = base_path.replace("offline_rl_dataset", "offline_rl_dataset_mbpp")
     if args.begin_with > 0 or args.num_samples != -1:
         batch_suffix = f"_batch_{start_idx}_{end_idx-1}"
         single_suffix = f"_pattern_{pattern_idx}_budget_{budget_idx}{batch_suffix}"
@@ -245,7 +243,7 @@ def generate_cache_single_pattern_budget(args, pattern_idx: int, budget_idx: int
     print(f"Budget: {target_budget} (idx={budget_idx})")
     if incorrect_res_data:
         base_dir = os.path.dirname(output_path)
-        incorrect_base_path = base_path.replace("offline_rl_dataset_mbpp", "incorrect_res_data_mbpp")
+        incorrect_base_path = base_path.replace("offline_rl_dataset", "incorrect_res_data")
         incorrect_output_path = f"{incorrect_base_path}_incorrect{single_suffix}.json"
         with open(incorrect_output_path, 'w', encoding='utf-8') as f:
             for entry in incorrect_res_data:
@@ -389,10 +387,6 @@ def main(args):
         for p in workers:
             p.join()
     output_path = params['data']['offline_dataset_path']
-    base_path, ext = os.path.splitext(output_path)
-    if "_mbpp" not in base_path:
-        base_path = base_path.replace("offline_rl_dataset", "offline_rl_dataset_mbpp")
-        output_path = f"{base_path}{ext}"
     if args.begin_with > 0 or args.num_samples != -1:
         base_path, ext = os.path.splitext(output_path)
         batch_suffix = f"_batch_{start_idx}_{end_idx-1}"
@@ -406,9 +400,9 @@ def main(args):
         base_dir = os.path.dirname(output_path)
         if args.begin_with > 0 or args.num_samples != -1:
             batch_suffix = f"_batch_{start_idx}_{end_idx-1}"
-            incorrect_output_path = os.path.join(base_dir, f"incorrect_res_data_mbpp{batch_suffix}.json")
+            incorrect_output_path = os.path.join(base_dir, f"incorrect_res_data{batch_suffix}.json")
         else:
-            incorrect_output_path = os.path.join(base_dir, "incorrect_res_data_mbpp.json")
+            incorrect_output_path = os.path.join(base_dir, "incorrect_res_data.json")
         os.makedirs(os.path.dirname(incorrect_output_path), exist_ok=True)
         with open(incorrect_output_path, 'w', encoding='utf-8') as f:
             for entry in incorrect_res_data:


### PR DESCRIPTION
## Summary
- document the public sources and local paths for GSM8K, MBPP, and MATH
- add a script to download the raw benchmarks into the repository layout
- explain how to generate the offline RL cache files used by offline training
- align the MBPP offline cache output path with the training config
- improve the missing-dataset guidance in offline training

## Testing
- D:\Anaconda\envs\BAMAS\python.exe -m py_compile scripts\download_real_datasets.py scripts\generate_mbpp_training_cache.py main_train_offline.py
- D:\Anaconda\envs\BAMAS\python.exe scripts\download_real_datasets.py --help
- D:\Anaconda\envs\BAMAS\python.exe main_train_offline.py --help
